### PR TITLE
chore: update call to get S3 file to use bucket name rather than ARN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ notebooks/
 
 .vscode/settings.json
 uv.lock
+.venvcon/*

--- a/docs/deploy.http
+++ b/docs/deploy.http
@@ -17,7 +17,7 @@
 
 # @name listProcesses
 GET {{scheme}}://{{ades}}/{{username}}/ogc-api/processes HTTP/1.1
-Authorization: Bearer {{geodowd_token}}
+Authorization: Bearer {{token}}
 Accept: application/json
 
 ###

--- a/get_asset_values.cwl
+++ b/get_asset_values.cwl
@@ -57,7 +57,7 @@ $graph:
         NetworkAccess:
             networkAccess: true
         DockerRequirement:
-            dockerPull: public.ecr.aws/z0u8g6n1/get_asset_values:xarrayg
+            dockerPull: public.ecr.aws/z0u8g6n1/get_asset_values:latest
     baseCommand: main.py
     inputs:
         assets:

--- a/src/app/points_data.py
+++ b/src/app/points_data.py
@@ -64,11 +64,7 @@ class SpatialData:
             self.data = self.load_json_from_file(temp_file.name)
         else:
             base_name = os.path.basename(self.source)
-            user = self.source.split("/")[0]
-            bucket_arn = (
-                "arn:aws:s3:eu-west-2:312280911266:accesspoint/"
-                f"eodhp-test-gstjkhpo-{user}-s3"
-            )
+            bucket_arn = "workspaces-eodhp-test"
             logger.info(f"Downloading {self.source} from {bucket_arn}...")
 
             # Use pathlib.Path to get the name without suffix


### PR DESCRIPTION
Update to match update to hub where to download an S3 file you need to use the bucket name rather than the ARN.